### PR TITLE
Redirect stderr of manpath to /dev/null

### DIFF
--- a/sources/man.sh
+++ b/sources/man.sh
@@ -5,7 +5,7 @@ path='/usr/share/man'
 get_man_path() {
 
 	man_default_paths="$(
-		manpath | awk -F':' "{
+		manpath 2>/dev/null | awk -F':' "{
 			OFS=\" \";
 			for(i=1; i<=NF; i++)
 				if(\"$lang\"!=\"en\")


### PR DESCRIPTION
Suppress the following annoying error messages everytime I run wikiman:

```
manpath: warning: $MANPATH set, ignoring /etc/man_db.conf
manpath: warning: $MANPATH set, ignoring /etc/man_db.conf
```