### PR TITLE
Update Makefile to allow for paths with spaces in them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,76 +4,74 @@ RELEASE=	1
 UPSTREAM=	https://github.com/filiparag/wikiman
 SOURCES= 	${UPSTREAM}/releases/download/
 
-MKFILEREL!=	echo ${.MAKE.MAKEFILES} | sed 's/.* //'
-MKFILEABS!=	readlink -f ${MKFILEREL} 2>/dev/null
-MKFILEABS+= $(shell readlink -f ${MAKEFILE_LIST})
-WORKDIR!=	dirname ${MKFILEABS} 2>/dev/null
+MKFILEABS= 	$(shell readlink -f ${MAKEFILE_LIST})
+WORKDIR!=	dirname "${MKFILEABS}"
 
 BUILDDIR:=	${WORKDIR}/pkgbuild
-SOURCESDIR:=${WORKDIR}/srcbuild
+SOURCESDIR:= 	${WORKDIR}/srcbuild
 PLISTFILE:=	${WORKDIR}/pkg-plist
 
 all: core widgets completions config docs
 
 core:
 
-	@mkdir -p	${BUILDDIR}/usr/bin \
-	 			${BUILDDIR}/usr/share/${NAME} \
-				${BUILDDIR}/usr/share/licenses/${NAME} \
-				${BUILDDIR}/usr/share/man/man1
-	@install 	-Dm755 	${WORKDIR}/${NAME}.sh 	${BUILDDIR}/usr/bin/${NAME}
-	@cp 		-fr 	${WORKDIR}/sources 		${BUILDDIR}/usr/share/${NAME}
-	@install 	-Dm644 	${WORKDIR}/LICENSE 		${BUILDDIR}/usr/share/licenses/${NAME}
-	@gzip 		-k		${WORKDIR}/${NAME}.1.man
-	@mv 		${WORKDIR}/${NAME}.1.man.gz		${BUILDDIR}/usr/share/man/man1/${NAME}.1.gz
+	@mkdir -p	"${BUILDDIR}/usr/bin" \
+			"${BUILDDIR}/usr/share/${NAME}" \
+			"${BUILDDIR}/usr/share/licenses/${NAME}" \
+			"${BUILDDIR}/usr/share/man/man1"
+	@install 	-Dm755 	"${WORKDIR}/${NAME}.sh"	"${BUILDDIR}/usr/bin/${NAME}"
+	@cp 		-fr 	"${WORKDIR}/sources"	"${BUILDDIR}/usr/share/${NAME}"
+	@install 	-Dm644 	"${WORKDIR}/LICENSE"	"${BUILDDIR}/usr/share/licenses/${NAME}"
+	@gzip 		-k		"${WORKDIR}/${NAME}.1.man"
+	@mv 		"${WORKDIR}/${NAME}.1.man.gz"	"${BUILDDIR}/usr/share/man/man1/${NAME}.1.gz"
 
 widgets: core
 
-	@mkdir -p 	${BUILDDIR}/usr/share/${NAME}
-	@cp 		-fr 	${WORKDIR}/widgets 		${BUILDDIR}/usr/share/${NAME}
+	@mkdir -p 	"${BUILDDIR}/usr/share/${NAME}"
+	@cp 		-fr 	"${WORKDIR}/widgets"	"${BUILDDIR}/usr/share/${NAME}"
 
 completions: core
 
-	@mkdir -p 	${BUILDDIR}/etc/bash_completion.d \
-				${BUILDDIR}/usr/share/fish/completions \
-				${BUILDDIR}/usr/share/zsh/site-functions
-	@install 	-Dm644 	${WORKDIR}/completions/completions.bash	${BUILDDIR}/etc/bash_completion.d/${NAME}-completion.bash
-	@install 	-Dm644 	${WORKDIR}/completions/completions.fish	${BUILDDIR}/usr/share/fish/completions/${NAME}.fish
-	@install 	-Dm644 	${WORKDIR}/completions/completions.zsh	${BUILDDIR}/usr/share/zsh/site-functions/_${NAME}
+	@mkdir -p 	"${BUILDDIR}/etc/bash_completion.d" \
+			"${BUILDDIR}/usr/share/fish/completions" \
+			"${BUILDDIR}/usr/share/zsh/site-functions"
+	@install 	-Dm644 	"${WORKDIR}/completions/completions.bash"	"${BUILDDIR}/etc/bash_completion.d/${NAME}-completion.bash"
+	@install 	-Dm644 	"${WORKDIR}/completions/completions.fish"	"${BUILDDIR}/usr/share/fish/completions/${NAME}.fish"
+	@install 	-Dm644 	"${WORKDIR}/completions/completions.zsh"	"${BUILDDIR}/usr/share/zsh/site-functions/_${NAME}"
 
 config:
 
-	@mkdir -p 	${BUILDDIR}/etc
-	@install 	-Dm644 	${WORKDIR}/${NAME}.conf ${BUILDDIR}/etc
+	@mkdir -p 	"${BUILDDIR}/etc"
+	@install 	-Dm644 	"${WORKDIR}/${NAME}.conf" 	"${BUILDDIR}/etc"
 
 docs:
 
-	@mkdir -p 	${BUILDDIR}/usr/share/doc/${NAME}
-	@install 	-Dm644 	${WORKDIR}/README.md 	${BUILDDIR}/usr/share/doc/${NAME}
+	@mkdir -p 	"${BUILDDIR}/usr/share/doc/${NAME}"
+	@install 	-Dm644 	"${WORKDIR}/README.md"		"${BUILDDIR}/usr/share/doc/${NAME}"
 
 reinstall: install
 install: all
 
 	@mkdir -p 	$(prefix)/
-	@cp -fr 	${BUILDDIR}/* $(prefix)/
+	@cp -fr 	"${BUILDDIR}"/* $(prefix)/
 
 plist: all
 
-	@find 		${BUILDDIR} -type f > ${PLISTFILE}
-	@sed -i 	's|${BUILDDIR}/||' ${PLISTFILE}
+	@find 		"${BUILDDIR}" -type f > "${PLISTFILE}"
+	@sed -i 	's|${BUILDDIR}/||' "${PLISTFILE}"
 
 dist: package
 package: all
 
-	@tar czf ${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz ${BUILDDIR}
+	@tar czf "${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz" "${BUILDDIR}"
 
 distclean: clean
 clean:
 
-	@rm -f 	${PLISTFILE} \
-			${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz
-	@rm -rf ${BUILDDIR} \
-			${SOURCESDIR}
+	@rm -f 	"${PLISTFILE}" \
+		"${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz"
+	@rm -rf	"${BUILDDIR}" \
+		"${SOURCESDIR}"
 
 deinstall: uninstall
 uninstall:
@@ -102,80 +100,79 @@ local:
 
 	@test ! -d	${BUILDDIR}/usr/local
 
-	@mkdir -p	${BUILDDIR}/tmp ${BUILDDIR}/usr ${BUILDDIR}/etc
-	@mv			${BUILDDIR}/usr ${BUILDDIR}/etc ${BUILDDIR}/tmp
-	@mkdir -p	${BUILDDIR}/usr/local/usr ${BUILDDIR}/usr/local/etc
-	@mv			${BUILDDIR}/tmp/* ${BUILDDIR}/usr/local
-	@rm -rf		${BUILDDIR}/tmp ${BUILDDIR}/etc
+	@mkdir -p	"${BUILDDIR}/tmp" "${BUILDDIR}/usr" "${BUILDDIR}/etc"
+	@mv			"${BUILDDIR}/usr" "${BUILDDIR}/etc" "${BUILDDIR}/tmp"
+	@mkdir -p	"${BUILDDIR}/usr/local/usr" "${BUILDDIR}/usr/local/etc"
+	@mv			"${BUILDDIR}/tmp/*" "${BUILDDIR}/usr/local"
+	@rm -rf		"${BUILDDIR}/tmp" "${BUILDDIR}/etc"
 
-	@mkdir -p	${SOURCESDIR}/usr/local/share ${SOURCESDIR}/usr/share/doc
-	@mv			${SOURCESDIR}/usr/share/doc ${SOURCESDIR}/usr/local/share/doc
-	@rm -rf		${SOURCESDIR}/usr/share
+	@mkdir -p	"${SOURCESDIR}/usr/local/share" "${SOURCESDIR}/usr/share/doc"
+	@mv			"${SOURCESDIR}/usr/share/doc" "${SOURCESDIR}/usr/local/share/doc"
+	@rm -rf		"${SOURCESDIR}/usr/share"
 
 .PHONY: help
 help:
-
-	@sed -n '/^[-a-z]\+:/p;' ${MKFILEABS}
+	@sed -n '/^[-a-z]\+:/p;' "${MKFILEABS}"
 
 source:
 
-	@mkdir -p 	${SOURCESDIR}/usr/share/doc \
-				${SOURCESDIR}/tmp
+	@mkdir -p 	"${SOURCESDIR}/usr/share/doc" \
+			"${SOURCESDIR}/tmp"
 
 source-all: source-arch source-gentoo source-fbsd source-tldr
 
 source-reinstall: source-install
 source-install:
 
-	@[ -d ${SOURCESDIR}/usr/share/doc ] && \
+	@[ -d "${SOURCESDIR}/usr/share/doc" ] && \
 				mkdir -p $(prefix)/usr/share/doc && \
-				cp -rf 	 ${SOURCESDIR}/usr/share/doc $(prefix)/usr/share || true
+				cp -rf 	 "${SOURCESDIR}/usr/share/doc" $(prefix)/usr/share || true
 
-	@[ -d ${SOURCESDIR}/usr/local/share/doc ] && \
+	@[ -d "${SOURCESDIR}/usr/local/share/doc" ] && \
 				mkdir -p $(prefix)/usr/local/share/doc && \
-				cp -rf 	 ${SOURCESDIR}/usr/local/share/doc $(prefix)/usr/local/share || true
+				cp -rf 	 "${SOURCESDIR}/usr/local/share/doc" $(prefix)/usr/local/share || true
 
 source-clean:
 
-	@rm -rf 	${SOURCESDIR}
+	@rm -rf 		"${SOURCESDIR}"
 
 source-deinstall: source-uninstall
 source-uninstall:
 
 	@rm -rf		$(prefix)/usr/share/doc/arch-wiki/html \
-				$(prefix)/usr/share/doc/gentoo-wiki \
-				$(prefix)/usr/share/doc/freebsd-docs \
-				$(prefix)/usr/share/doc/tldr-pages
+			$(prefix)/usr/share/doc/gentoo-wiki \
+			$(prefix)/usr/share/doc/freebsd-docs \
+			$(prefix)/usr/share/doc/tldr-pages
 
 	@rm -rf		$(prefix)/usr/local/share/doc/arch-wiki/html \
-				$(prefix)/usr/local/share/doc/gentoo-wiki \
-				$(prefix)/usr/local/share/doc/freebsd-docs \
-				$(prefix)/usr/local/share/doc/tldr-pages
+			$(prefix)/usr/local/share/doc/gentoo-wiki \
+			$(prefix)/usr/local/share/doc/freebsd-docs \
+			$(prefix)/usr/local/share/doc/tldr-pages
 
 source-arch: source
 
-	@curl -L 	'${SOURCES}/2.13/arch-wiki_20211009.tar.xz' -o ${SOURCESDIR}/tmp/arch.tar.xz
-	@sha1sum 	${SOURCESDIR}/tmp/arch.tar.xz | grep -q '7b5c90b90e159f81dfc7c7e1373a4f6715810dc3'
-	@tar xf 	${SOURCESDIR}/tmp/arch.tar.xz -C ${SOURCESDIR}
-	@rm -rf 	${SOURCESDIR}/tmp
+	@curl -L 	'${SOURCES}/2.13/arch-wiki_20211009.tar.xz' -o "${SOURCESDIR}/tmp/arch.tar.xz"
+	@sha1sum 	"${SOURCESDIR}/tmp/arch.tar.xz" | grep -q '7b5c90b90e159f81dfc7c7e1373a4f6715810dc3'
+	@tar xf 	"${SOURCESDIR}/tmp/arch.tar.xz" -C "${SOURCESDIR}"
+	@rm -rf	 	"${SOURCESDIR}/tmp"
 
 source-gentoo: source
 
-	@curl -L 	'${SOURCES}/2.7/gentoo-wiki_20200831-1.tar.xz' -o ${SOURCESDIR}/tmp/gentoo.tar.xz
-	@sha1sum 	${SOURCESDIR}/tmp/gentoo.tar.xz | grep -q '5abbba5ca440865a766bbb939a3cbb5194096dfb'
-	@tar xf 	${SOURCESDIR}/tmp/gentoo.tar.xz -C ${SOURCESDIR}
-	@rm -rf 	${SOURCESDIR}/tmp
-	
+	@curl -L 	'${SOURCES}/2.7/gentoo-wiki_20200831-1.tar.xz' -o "${SOURCESDIR}/tmp/gentoo.tar.xz"
+	@sha1sum 	"${SOURCESDIR}/tmp/gentoo.tar.xz" | grep -q '5abbba5ca440865a766bbb939a3cbb5194096dfb'
+	@tar xf 	"${SOURCESDIR}/tmp/gentoo.tar.xz" -C "${SOURCESDIR}"
+	@rm -rf	 	"${SOURCESDIR}/tmp"
+
 source-fbsd: source
 
-	@curl -L 	'${SOURCES}/2.13/freebsd-docs_20211009.tar.xz' -o ${SOURCESDIR}/tmp/fbsd.tar.xz
-	@sha1sum 	${SOURCESDIR}/tmp/fbsd.tar.xz | grep -q '96c00949613fd21f107d3bf8f1df59ebd61cc40a'
-	@tar xf 	${SOURCESDIR}/tmp/fbsd.tar.xz -C ${SOURCESDIR}
-	@rm -rf 	${SOURCESDIR}/tmp
+	@curl -L 	'${SOURCES}/2.13/freebsd-docs_20211009.tar.xz' -o "${SOURCESDIR}/tmp/fbsd.tar.xz"
+	@sha1sum 	"${SOURCESDIR}/tmp/fbsd.tar.xz" | grep -q '96c00949613fd21f107d3bf8f1df59ebd61cc40a'
+	@tar xf 	"${SOURCESDIR}/tmp/fbsd.tar.xz" -C "${SOURCESDIR}"
+	@rm -rf	 	"${SOURCESDIR}/tmp"
 
 source-tldr: source
 
-	@curl -L 	'${SOURCES}/2.13/tldr-pages_20211009.tar.xz' -o ${SOURCESDIR}/tmp/tldr.tar.xz
-	@sha1sum 	${SOURCESDIR}/tmp/tldr.tar.xz | grep -q 'ea7a8dd21ca79079762e3b3c25ad048df0e800a8'
-	@tar xf 	${SOURCESDIR}/tmp/tldr.tar.xz -C ${SOURCESDIR}
-	@rm -rf 	${SOURCESDIR}/tmp
+	@curl -L 	'${SOURCES}/2.13/tldr-pages_20211009.tar.xz' -o "${SOURCESDIR}/tmp/tldr.tar.xz"
+	@sha1sum 	"${SOURCESDIR}/tmp/tldr.tar.xz" | grep -q 'ea7a8dd21ca79079762e3b3c25ad048df0e800a8'
+	@tar xf 	"${SOURCESDIR}/tmp/tldr.tar.xz" -C "${SOURCESDIR}"
+	@rm -rf	 	"${SOURCESDIR}/tmp"

--- a/Makefile
+++ b/Makefile
@@ -2,122 +2,122 @@ NAME=		wikiman
 VERSION=	2.12.2
 RELEASE=	1
 UPSTREAM=	https://github.com/filiparag/wikiman
-SOURCES= 	${UPSTREAM}/releases/download/
+SOURCES=	${UPSTREAM}/releases/download/
 
-MKFILEABS= 	$(shell readlink -f ${MAKEFILE_LIST})
+MKFILEABS=	$(shell readlink -f ${MAKEFILE_LIST})
 WORKDIR!=	dirname "${MKFILEABS}"
 
 BUILDDIR:=	${WORKDIR}/pkgbuild
-SOURCESDIR:= 	${WORKDIR}/srcbuild
+SOURCESDIR:=	${WORKDIR}/srcbuild
 PLISTFILE:=	${WORKDIR}/pkg-plist
 
 all: core widgets completions config docs
 
 core:
 
-	@mkdir -p	"${BUILDDIR}/usr/bin" \
-			"${BUILDDIR}/usr/share/${NAME}" \
-			"${BUILDDIR}/usr/share/licenses/${NAME}" \
-			"${BUILDDIR}/usr/share/man/man1"
-	@install 	-Dm755 	"${WORKDIR}/${NAME}.sh"	"${BUILDDIR}/usr/bin/${NAME}"
-	@cp 		-fr 	"${WORKDIR}/sources"	"${BUILDDIR}/usr/share/${NAME}"
-	@install 	-Dm644 	"${WORKDIR}/LICENSE"	"${BUILDDIR}/usr/share/licenses/${NAME}"
-	@gzip 		-k		"${WORKDIR}/${NAME}.1.man"
-	@mv 		"${WORKDIR}/${NAME}.1.man.gz"	"${BUILDDIR}/usr/share/man/man1/${NAME}.1.gz"
+	@mkdir		-p	"${BUILDDIR}/usr/bin" \
+				"${BUILDDIR}/usr/share/${NAME}" \
+				"${BUILDDIR}/usr/share/licenses/${NAME}" \
+				"${BUILDDIR}/usr/share/man/man1"
+	@install	-Dm755	"${WORKDIR}/${NAME}.sh"	"${BUILDDIR}/usr/bin/${NAME}"
+	@cp		-fr	"${WORKDIR}/sources" "${BUILDDIR}/usr/share/${NAME}"
+	@install	-Dm644	"${WORKDIR}/LICENSE" "${BUILDDIR}/usr/share/licenses/${NAME}"
+	@gzip		-k	"${WORKDIR}/${NAME}.1.man"
+	@mv			"${WORKDIR}/${NAME}.1.man.gz" "${BUILDDIR}/usr/share/man/man1/${NAME}.1.gz"
 
 widgets: core
 
-	@mkdir -p 	"${BUILDDIR}/usr/share/${NAME}"
-	@cp 		-fr 	"${WORKDIR}/widgets"	"${BUILDDIR}/usr/share/${NAME}"
+	@mkdir		-p	"${BUILDDIR}/usr/share/${NAME}"
+	@cp		-fr	"${WORKDIR}/widgets" "${BUILDDIR}/usr/share/${NAME}"
 
 completions: core
 
-	@mkdir -p 	"${BUILDDIR}/etc/bash_completion.d" \
-			"${BUILDDIR}/usr/share/fish/completions" \
-			"${BUILDDIR}/usr/share/zsh/site-functions"
-	@install 	-Dm644 	"${WORKDIR}/completions/completions.bash"	"${BUILDDIR}/etc/bash_completion.d/${NAME}-completion.bash"
-	@install 	-Dm644 	"${WORKDIR}/completions/completions.fish"	"${BUILDDIR}/usr/share/fish/completions/${NAME}.fish"
-	@install 	-Dm644 	"${WORKDIR}/completions/completions.zsh"	"${BUILDDIR}/usr/share/zsh/site-functions/_${NAME}"
+	@mkdir		-p	"${BUILDDIR}/etc/bash_completion.d" \
+				"${BUILDDIR}/usr/share/fish/completions" \
+				"${BUILDDIR}/usr/share/zsh/site-functions"
+	@install	-Dm644	"${WORKDIR}/completions/completions.bash" "${BUILDDIR}/etc/bash_completion.d/${NAME}-completion.bash"
+	@install	-Dm644	"${WORKDIR}/completions/completions.fish" "${BUILDDIR}/usr/share/fish/completions/${NAME}.fish"
+	@install	-Dm644	"${WORKDIR}/completions/completions.zsh" "${BUILDDIR}/usr/share/zsh/site-functions/_${NAME}"
 
 config:
 
-	@mkdir -p 	"${BUILDDIR}/etc"
-	@install 	-Dm644 	"${WORKDIR}/${NAME}.conf" 	"${BUILDDIR}/etc"
+	@mkdir		-p	"${BUILDDIR}/etc"
+	@install	-Dm644 	"${WORKDIR}/${NAME}.conf" "${BUILDDIR}/etc"
 
 docs:
 
-	@mkdir -p 	"${BUILDDIR}/usr/share/doc/${NAME}"
-	@install 	-Dm644 	"${WORKDIR}/README.md"		"${BUILDDIR}/usr/share/doc/${NAME}"
+	@mkdir		-p	"${BUILDDIR}/usr/share/doc/${NAME}"
+	@install	-Dm644	"${WORKDIR}/README.md" "${BUILDDIR}/usr/share/doc/${NAME}"
 
 reinstall: install
 install: all
 
-	@mkdir -p 	$(prefix)/
-	@cp -fr 	"${BUILDDIR}"/* $(prefix)/
+	@mkdir		-p	$(prefix)/
+	@cp		-fr	"${BUILDDIR}"/* $(prefix)/
 
 plist: all
 
-	@find 		"${BUILDDIR}" -type f > "${PLISTFILE}"
-	@sed -i 	's|${BUILDDIR}/||' "${PLISTFILE}"
+	@find			"${BUILDDIR}" -type f > "${PLISTFILE}"
+	@sed		-i	's|${BUILDDIR}/||' "${PLISTFILE}"
 
 dist: package
 package: all
 
-	@tar czf "${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz" "${BUILDDIR}"
+	@tar		czf	"${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz" "${BUILDDIR}"
 
 distclean: clean
 clean:
 
-	@rm -f 	"${PLISTFILE}" \
-		"${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz"
-	@rm -rf	"${BUILDDIR}" \
-		"${SOURCESDIR}"
+	@rm		-f	"${PLISTFILE}" \
+				"${WORKDIR}/${NAME}-${VERSION}-${RELEASE}.tar.gz"
+	@rm		-rf	"${BUILDDIR}" \
+				"${SOURCESDIR}"
 
 deinstall: uninstall
 uninstall:
 
-	@rm -f	$(prefix)/etc/${NAME}.conf \
-			$(prefix)/usr/bin/${NAME} \
-			$(prefix)/usr/share/man/man1/${NAME}.1.gz \
-			$(prefix)/etc/bash_completion.d/${NAME}-completion.bash \
-			$(prefix)/usr/share/fish/completions/${NAME}.fish \
-			$(prefix)/usr/share/zsh/site-functions/_${NAME}
-	@rm -rf $(prefix)/usr/share/${NAME} \
-			$(prefix)/usr/share/licenses/${NAME} \
-			$(prefix)/usr/share/doc/${NAME}
+	@rm		-f	$(prefix)/etc/${NAME}.conf \
+				$(prefix)/usr/bin/${NAME} \
+				$(prefix)/usr/share/man/man1/${NAME}.1.gz \
+				$(prefix)/etc/bash_completion.d/${NAME}-completion.bash \
+				$(prefix)/usr/share/fish/completions/${NAME}.fish \
+				$(prefix)/usr/share/zsh/site-functions/_${NAME}
+	@rm		-rf	$(prefix)/usr/share/${NAME} \
+				$(prefix)/usr/share/licenses/${NAME} \
+				$(prefix)/usr/share/doc/${NAME}
 
-	@rm -f	$(prefix)/usr/local/etc/${NAME}.conf \
-			$(prefix)/usr/local/bin/${NAME} \
-			$(prefix)/usr/local/share/man/man1/${NAME}.1.gz \
-			$(prefix)/etc/bash_completion.d/${NAME}-completion.bash \
-			$(prefix)/usr/share/fish/completions/${NAME}.fish \
-			$(prefix)/usr/share/zsh/site-functions/_${NAME}
-	@rm -rf $(prefix)/usr/local/share/${NAME} \
-			$(prefix)/usr/local/share/licenses/${NAME} \
-			$(prefix)/usr/local/share/doc/${NAME}
+	@rm		-f	$(prefix)/usr/local/etc/${NAME}.conf \
+				$(prefix)/usr/local/bin/${NAME} \
+				$(prefix)/usr/local/share/man/man1/${NAME}.1.gz \
+				$(prefix)/etc/bash_completion.d/${NAME}-completion.bash \
+				$(prefix)/usr/share/fish/completions/${NAME}.fish \
+				$(prefix)/usr/share/zsh/site-functions/_${NAME}
+	@rm		-rf	$(prefix)/usr/local/share/${NAME} \
+				$(prefix)/usr/local/share/licenses/${NAME} \
+				$(prefix)/usr/local/share/doc/${NAME}
 
 local:
 
-	@test ! -d	${BUILDDIR}/usr/local
+	@test		! -d	${BUILDDIR}/usr/local
 
-	@mkdir -p	"${BUILDDIR}/tmp" "${BUILDDIR}/usr" "${BUILDDIR}/etc"
+	@mkdir		-p	"${BUILDDIR}/tmp" "${BUILDDIR}/usr" "${BUILDDIR}/etc"
 	@mv			"${BUILDDIR}/usr" "${BUILDDIR}/etc" "${BUILDDIR}/tmp"
-	@mkdir -p	"${BUILDDIR}/usr/local/usr" "${BUILDDIR}/usr/local/etc"
+	@mkdir		-p	"${BUILDDIR}/usr/local/usr" "${BUILDDIR}/usr/local/etc"
 	@mv			"${BUILDDIR}/tmp/*" "${BUILDDIR}/usr/local"
-	@rm -rf		"${BUILDDIR}/tmp" "${BUILDDIR}/etc"
+	@rm		-rf	"${BUILDDIR}/tmp" "${BUILDDIR}/etc"
 
-	@mkdir -p	"${SOURCESDIR}/usr/local/share" "${SOURCESDIR}/usr/share/doc"
+	@mkdir		-p	"${SOURCESDIR}/usr/local/share" "${SOURCESDIR}/usr/share/doc"
 	@mv			"${SOURCESDIR}/usr/share/doc" "${SOURCESDIR}/usr/local/share/doc"
-	@rm -rf		"${SOURCESDIR}/usr/share"
+	@rm		-rf	"${SOURCESDIR}/usr/share"
 
 .PHONY: help
 help:
-	@sed -n '/^[-a-z]\+:/p;' "${MKFILEABS}"
+	@sed		-n	'/^[-a-z]\+:/p;' "${MKFILEABS}"
 
 source:
 
-	@mkdir -p 	"${SOURCESDIR}/usr/share/doc" \
-			"${SOURCESDIR}/tmp"
+	@mkdir		-p	"${SOURCESDIR}/usr/share/doc" \
+				"${SOURCESDIR}/tmp"
 
 source-all: source-arch source-gentoo source-fbsd source-tldr
 
@@ -125,54 +125,54 @@ source-reinstall: source-install
 source-install:
 
 	@[ -d "${SOURCESDIR}/usr/share/doc" ] && \
-				mkdir -p $(prefix)/usr/share/doc && \
-				cp -rf 	 "${SOURCESDIR}/usr/share/doc" $(prefix)/usr/share || true
+		mkdir	-p	$(prefix)/usr/share/doc && \
+		cp	-rf	"${SOURCESDIR}/usr/share/doc" $(prefix)/usr/share || true
 
 	@[ -d "${SOURCESDIR}/usr/local/share/doc" ] && \
-				mkdir -p $(prefix)/usr/local/share/doc && \
-				cp -rf 	 "${SOURCESDIR}/usr/local/share/doc" $(prefix)/usr/local/share || true
+		mkdir	-p	$(prefix)/usr/local/share/doc && \
+		cp	-rf	"${SOURCESDIR}/usr/local/share/doc" $(prefix)/usr/local/share || true
 
 source-clean:
 
-	@rm -rf 		"${SOURCESDIR}"
+	@rm		-rf	"${SOURCESDIR}"
 
 source-deinstall: source-uninstall
 source-uninstall:
 
-	@rm -rf		$(prefix)/usr/share/doc/arch-wiki/html \
-			$(prefix)/usr/share/doc/gentoo-wiki \
-			$(prefix)/usr/share/doc/freebsd-docs \
-			$(prefix)/usr/share/doc/tldr-pages
+	@rm		-rf	$(prefix)/usr/share/doc/arch-wiki/html \
+				$(prefix)/usr/share/doc/gentoo-wiki \
+				$(prefix)/usr/share/doc/freebsd-docs \
+				$(prefix)/usr/share/doc/tldr-pages
 
-	@rm -rf		$(prefix)/usr/local/share/doc/arch-wiki/html \
-			$(prefix)/usr/local/share/doc/gentoo-wiki \
-			$(prefix)/usr/local/share/doc/freebsd-docs \
-			$(prefix)/usr/local/share/doc/tldr-pages
+	@rm		-rf	$(prefix)/usr/local/share/doc/arch-wiki/html \
+				$(prefix)/usr/local/share/doc/gentoo-wiki \
+				$(prefix)/usr/local/share/doc/freebsd-docs \
+				$(prefix)/usr/local/share/doc/tldr-pages
 
 source-arch: source
 
-	@curl -L 	'${SOURCES}/2.13/arch-wiki_20211009.tar.xz' -o "${SOURCESDIR}/tmp/arch.tar.xz"
-	@sha1sum 	"${SOURCESDIR}/tmp/arch.tar.xz" | grep -q '7b5c90b90e159f81dfc7c7e1373a4f6715810dc3'
-	@tar xf 	"${SOURCESDIR}/tmp/arch.tar.xz" -C "${SOURCESDIR}"
-	@rm -rf	 	"${SOURCESDIR}/tmp"
+	@curl		-L	'${SOURCES}/2.13/arch-wiki_20211009.tar.xz' -o "${SOURCESDIR}/tmp/arch.tar.xz"
+	@sha1sum		"${SOURCESDIR}/tmp/arch.tar.xz" | grep -q '7b5c90b90e159f81dfc7c7e1373a4f6715810dc3'
+	@tar		xf	"${SOURCESDIR}/tmp/arch.tar.xz" -C "${SOURCESDIR}"
+	@rm		-rf	"${SOURCESDIR}/tmp"
 
 source-gentoo: source
 
-	@curl -L 	'${SOURCES}/2.7/gentoo-wiki_20200831-1.tar.xz' -o "${SOURCESDIR}/tmp/gentoo.tar.xz"
-	@sha1sum 	"${SOURCESDIR}/tmp/gentoo.tar.xz" | grep -q '5abbba5ca440865a766bbb939a3cbb5194096dfb'
-	@tar xf 	"${SOURCESDIR}/tmp/gentoo.tar.xz" -C "${SOURCESDIR}"
-	@rm -rf	 	"${SOURCESDIR}/tmp"
+	@curl		-L	'${SOURCES}/2.7/gentoo-wiki_20200831-1.tar.xz' -o "${SOURCESDIR}/tmp/gentoo.tar.xz"
+	@sha1sum		"${SOURCESDIR}/tmp/gentoo.tar.xz" | grep -q '5abbba5ca440865a766bbb939a3cbb5194096dfb'
+	@tar		xf	"${SOURCESDIR}/tmp/gentoo.tar.xz" -C "${SOURCESDIR}"
+	@rm		-rf	"${SOURCESDIR}/tmp"
 
 source-fbsd: source
 
-	@curl -L 	'${SOURCES}/2.13/freebsd-docs_20211009.tar.xz' -o "${SOURCESDIR}/tmp/fbsd.tar.xz"
-	@sha1sum 	"${SOURCESDIR}/tmp/fbsd.tar.xz" | grep -q '96c00949613fd21f107d3bf8f1df59ebd61cc40a'
-	@tar xf 	"${SOURCESDIR}/tmp/fbsd.tar.xz" -C "${SOURCESDIR}"
-	@rm -rf	 	"${SOURCESDIR}/tmp"
+	@curl		-L	'${SOURCES}/2.13/freebsd-docs_20211009.tar.xz' -o "${SOURCESDIR}/tmp/fbsd.tar.xz"
+	@sha1sum		"${SOURCESDIR}/tmp/fbsd.tar.xz" | grep -q '96c00949613fd21f107d3bf8f1df59ebd61cc40a'
+	@tar		xf	"${SOURCESDIR}/tmp/fbsd.tar.xz" -C "${SOURCESDIR}"
+	@rm		-rf	"${SOURCESDIR}/tmp"
 
 source-tldr: source
 
-	@curl -L 	'${SOURCES}/2.13/tldr-pages_20211009.tar.xz' -o "${SOURCESDIR}/tmp/tldr.tar.xz"
-	@sha1sum 	"${SOURCESDIR}/tmp/tldr.tar.xz" | grep -q 'ea7a8dd21ca79079762e3b3c25ad048df0e800a8'
-	@tar xf 	"${SOURCESDIR}/tmp/tldr.tar.xz" -C "${SOURCESDIR}"
-	@rm -rf	 	"${SOURCESDIR}/tmp"
+	@curl		-L	'${SOURCES}/2.13/tldr-pages_20211009.tar.xz' -o "${SOURCESDIR}/tmp/tldr.tar.xz"
+	@sha1sum		"${SOURCESDIR}/tmp/tldr.tar.xz" | grep -q 'ea7a8dd21ca79079762e3b3c25ad048df0e800a8'
+	@tar		xf	"${SOURCESDIR}/tmp/tldr.tar.xz" -C "${SOURCESDIR}"
+	@rm		-rf	"${SOURCESDIR}/tmp"


### PR DESCRIPTION
When I tried to use the Makefile to download the wiki sources it ended up deleting the
directory it was called from, due to the Makefile not being able to handle paths with
spaces in them.

The fix is to wrap the variables that hold the path in quotes when they are being passed
as arguments to commands.