### PR TITLE
readme: update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Follow [these](#additional-documentation-sources) instructions to enable optiona
 
 ### Arch Linux
 
-**Wikiman** is available in the [community repository](https://archlinux.org/packages/community/any/wikiman/) and can be installed via [pacman](https://wiki.archlinux.org/title/Pacman):
+Install from Arch Linux's [community](https://archlinux.org/packages/community/any/wikiman/) repository:
 
 ```bash
 pacman -S wikiman

--- a/README.md
+++ b/README.md
@@ -16,20 +16,37 @@ Follow [these](#additional-documentation-sources) instructions to enable optiona
 
 ## Installation
 
-### Arch Linux / Manjaro ([AUR](https://aur.archlinux.org/packages/wikiman/))
+### Arch Linux
+
+**Wikiman** is available in the [community repository](https://archlinux.org/packages/community/any/wikiman/) and can be installed via [pacman](https://wiki.archlinux.org/title/Pacman):
+
+```bash
+pacman -S wikiman
+
+# Optional: Enable Arch Wiki
+pacman -S arch-wiki-docs
+```
+
+Or you can download the latest *.pkg.tar.zst* package from [Releases](https://github.com/filiparag/wikiman/releases/latest/) tab.
+
+```bash
+sudo pacman -U wikiman*.pkg.tar.zst
+```
+
+### Manjaro
+
+Similar intructions with [Arch Linux](#arch-linux) apply.
+
 ```bash
 yay -Syu wikiman
 
 # Optional: Enable Arch Wiki
 yay -Syu arch-wiki-docs
 ```
-If you are running Manjaro, package `arch-wiki-docs` is not in official repositories.
-Follow [these](#installing-additional-sources) instructions to download it.
 
-Or download latest *.pkg.tar.zst* package from [Releases](https://github.com/filiparag/wikiman/releases/latest/) tab.
-```bash
-sudo pacman -U wikiman*.pkg.tar.zst
-```
+On Manjaro, the package `arch-wiki-docs` is not in official repositories.
+
+Follow [these](#installing-additional-sources) instructions to download it.
 
 ### Ubuntu / Debian
 

--- a/README.md
+++ b/README.md
@@ -27,26 +27,10 @@ pacman -S wikiman
 pacman -S arch-wiki-docs
 ```
 
-Or you can download the latest *.pkg.tar.zst* package from [Releases](https://github.com/filiparag/wikiman/releases/latest/) tab.
-
-```bash
+If you are running Manjaro or another Arch-based distribution, download the latest *.pkg.tar.zst* package from [Releases](https://github.com/filiparag/wikiman/releases/latest/) tab, and follow [these](https://github.com/filiparag/wikiman#installing-additional-sources) instructions to add Arch Wiki as a source.
+```sh
 sudo pacman -U wikiman*.pkg.tar.zst
 ```
-
-### Manjaro
-
-Similar intructions with [Arch Linux](#arch-linux) apply.
-
-```bash
-yay -Syu wikiman
-
-# Optional: Enable Arch Wiki
-yay -Syu arch-wiki-docs
-```
-
-On Manjaro, the package `arch-wiki-docs` is not in official repositories.
-
-Follow [these](#installing-additional-sources) instructions to download it.
 
 ### Ubuntu / Debian
 


### PR DESCRIPTION
`wikiman` is moved to the community repository: https://archlinux.org/packages/community/any/wikiman/

This PR also splits the Arch Linux and Manjaro instructions.
