### PR TITLE
readme: update link to Arch package repo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Follow [these](#additional-documentation-sources) instructions to enable optiona
 
 ### Arch Linux
 
-Install from Arch Linux's [community](https://archlinux.org/packages/community/any/wikiman/) repository:
+Install from Arch Linux's [extra](https://archlinux.org/packages/extra/any/wikiman/) repository:
 
 ```bash
 pacman -S wikiman


### PR DESCRIPTION
The Arch Linux `community` repository has been renamed to `extra`, so the [old link](https://archlinux.org/packages/community/any/wikiman/) leads to a 404. This PR fixes the link accordingly.