### PR TITLE
macOS And Homebrew Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,17 @@ source-install:
 		cp	-Rf 	${SOURCESDIR}/usr/local/share/doc \
 				$(prefix)/usr/local/share || true
 
+source-install-homebrew:
+	[ -d ${SOURCESDIR}/usr/share/doc ] && \
+		[ -d ${HOMEBREW_PREFIX}/share/doc ] && \
+		cp	-Rf 	${SOURCESDIR}/usr/share/doc \
+				${HOMEBREW_PREFIX}/share || true
+
+	[ -d ${SOURCESDIR}/usr/local/share/doc ] && \
+		[ -d ${HOMEBREW_PREFIX}/share/doc ] && \
+		cp	-Rf 	${SOURCESDIR}/usr/local/share/doc \
+				${HOMEBREW_PREFIX}/share || true
+
 source-clean:
 	rm		-rf 	${SOURCESDIR}
 
@@ -161,6 +172,12 @@ source-uninstall:
 				$(prefix)/usr/local/share/doc/freebsd-docs \
 				$(prefix)/usr/local/share/doc/gentoo-wiki \
 				$(prefix)/usr/local/share/doc/tldr-pages
+source-uninstall-homebrew:
+	rm		-rf	${HOMEBREW_PREFIX}/share/doc/arch-wiki/html \
+				${HOMEBREW_PREFIX}/share/doc/devdocs \
+				${HOMEBREW_PREFIX}/share/doc/freebsd-docs \
+				${HOMEBREW_PREFIX}/share/doc/gentoo-wiki \
+				${HOMEBREW_PREFIX}/share/doc/tldr-pages
 
 source-local:
 	test		! -d	${SOURCESDIR}/usr/local/share/doc

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,16 @@ RELEASE=	1
 UPSTREAM=	https://github.com/filiparag/wikiman
 UPSTREAM_API=	https://api.github.com/repos/filiparag/wikiman/releases/latest
 
+OS!= uname -s
+ifeq ($(OS), Darwin)
+	READLINK:= greadlink
+else
+	READLINK:= readlink
+endif
+
 MKFILEREL!=	echo ${.MAKE.MAKEFILES} | sed 's/.* //'
-MKFILEABS!=	readlink -f ${MKFILEREL} 2>/dev/null
-MKFILEABS+= 	$(shell readlink -f ${MAKEFILE_LIST})
+MKFILEABS!=	${READLINK} -f ${MKFILEREL} 2>/dev/null
+MKFILEABS+= 	$(shell ${READLINK} -f ${MAKEFILE_LIST})
 WORKDIR!=	dirname ${MKFILEABS} 2>/dev/null
 
 BUILDDIR:=	${WORKDIR}/pkgbuild
@@ -28,7 +35,7 @@ core:
 				${BUILDDIR}/usr/share/man/man1
 	install 	-Dm755 	${WORKDIR}/${NAME}.sh \
 				${BUILDDIR}/usr/bin/${NAME}
-	cp 		-fr 	${WORKDIR}/sources \
+	cp 		-fR 	${WORKDIR}/sources \
 				${BUILDDIR}/usr/share/${NAME}
 	install 	-Dm644 	${WORKDIR}/LICENSE \
 				${BUILDDIR}/usr/share/licenses/${NAME}
@@ -39,7 +46,7 @@ core:
 widgets: core
 	test		! -f	${BUILDDIR}/.local
 	mkdir		-p 	${BUILDDIR}/usr/share/${NAME}
-	cp 		-fr 	${WORKDIR}/widgets \
+	cp 		-fR 	${WORKDIR}/widgets \
 				${BUILDDIR}/usr/share/${NAME}
 
 completions: core
@@ -69,7 +76,7 @@ docs:
 reinstall: install
 install: all
 	mkdir		-p 	$(prefix)/
-	cp		-fr 	${BUILDDIR}/* \
+	cp		-fR 	${BUILDDIR}/* \
 				$(prefix)/
 
 plist: all
@@ -131,12 +138,12 @@ source-reinstall: source-install
 source-install:
 	[ -d ${SOURCESDIR}/usr/share/doc ] && \
 		mkdir	-p	$(prefix)/usr/share/doc && \
-		cp	-rf	${SOURCESDIR}/usr/share/doc \
+		cp	-Rf	${SOURCESDIR}/usr/share/doc \
 				$(prefix)/usr/share || true
 
 	[ -d ${SOURCESDIR}/usr/local/share/doc ] && \
 		mkdir	-p	$(prefix)/usr/local/share/doc && \
-		cp	-rf 	${SOURCESDIR}/usr/local/share/doc \
+		cp	-Rf 	${SOURCESDIR}/usr/local/share/doc \
 				$(prefix)/usr/local/share || true
 
 source-clean:

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,9 @@ RELEASE=	1
 UPSTREAM=	https://github.com/filiparag/wikiman
 UPSTREAM_API=	https://api.github.com/repos/filiparag/wikiman/releases/latest
 
-OS!= uname -s
-ifeq ($(OS), Darwin)
-	READLINK:= greadlink
-else
-	READLINK:= readlink
-endif
-
 MKFILEREL!=	echo ${.MAKE.MAKEFILES} | sed 's/.* //'
-MKFILEABS!=	${READLINK} -f ${MKFILEREL} 2>/dev/null
-MKFILEABS+= 	$(shell ${READLINK} -f ${MAKEFILE_LIST})
+MKFILEABS!=	readlink -f "${MKFILEREL}" 2>/dev/null
+MKFILEABS+= 	$(shell readlink -f ${MAKEFILE_LIST})
 WORKDIR!=	dirname ${MKFILEABS} 2>/dev/null
 
 BUILDDIR:=	${WORKDIR}/pkgbuild

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ source-install:
 		cp	-Rf 	${SOURCESDIR}/usr/local/share/doc \
 				$(prefix)/usr/local/share || true
 
-source-install-homebrew:
 	[ -d ${SOURCESDIR}/usr/share/doc ] && \
 		[ -d ${HOMEBREW_PREFIX}/share/doc ] && \
 		cp	-Rf 	${SOURCESDIR}/usr/share/doc \

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ Or download latest _.txz_ package from [Releases](https://github.com/filiparag/w
 pkg install wikiman*.txz
 ```
 
-### Manual installation for Linux and BSD
+### Manual installation for Linux, BSD, and macOS
 
 Dependencies: `man`, `fzf`, `ripgrep`, `awk`, `w3m`, `coreutils`, `parallel`
 
-Wikiman uses GNU `find` and `awk`, so BSD users have to install `findutils` and `gawk`.
+Wikiman uses GNU `find` and `awk`, so BSD and macOS users have to additionally install `findutils` and `gawk`.
+macOS users are also required to install and use `gmake` instead of the system-default `make`. That either requires replacing every subsequent call to `make` in this document with `gmake` or setting `alias make=gmake`.
 
 ```bash
 # Clone from GitHub
@@ -84,6 +85,9 @@ make all
 
 # Only for BSD users: install to /usr/local instead of /usr
 make local
+
+# Only for macOS users: install to $HOME/.local instead of /usr and ensure that $HOME/.local/bin is in your PATH
+make install prefix=$HOME/.local
 
 # Install Wikiman
 sudo make install

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pkg install wikiman*.txz
 
 Dependencies: `man`, `fzf`, `ripgrep`, `awk`, `w3m`, `coreutils`, `parallel`
 
+Wikiman uses GNU `find` and `awk`, so BSD users have to install `findutils` and `gawk`.
+
 ```bash
 # Clone from GitHub
 git clone 'https://github.com/filiparag/wikiman'
@@ -86,8 +88,6 @@ make local
 # Install Wikiman
 sudo make install
 ```
-
-Wikiman uses GNU `find` and `awk`, so BSD users have to install `findutils` and `gawk`.
 
 ## Additional documentation sources
 

--- a/wikiman.sh
+++ b/wikiman.sh
@@ -63,6 +63,9 @@ init() {
 		'/usr/local/bin'|'/usr/local/sbin')
 			conf_sys_usr='/usr/local';
 			conf_sys_etc='/usr/local/etc';;
+		${HOMEBREW_PREFIX+"$HOMEBREW_PREFIX/bin"})
+			conf_sys_usr="$HOMEBREW_PREFIX";
+			conf_sys_etc="$HOMEBREW_PREFIX/etc";;
 		*)
 			case "$(dirname "$(command -v wikiman)")" in
 				"$HOME/bin"|"$HOME/.local/bin")
@@ -77,6 +80,9 @@ init() {
 					>&2 echo 'warning: unsupported installation path, using fallback for BSD' ;
 					conf_sys_usr='/usr/local';
 					conf_sys_etc='/usr/local/etc';;
+				${HOMEBREW_PREFIX+"$HOMEBREW_PREFIX/bin"})
+					conf_sys_usr="$HOMEBREW_PREFIX";
+					conf_sys_etc="$HOMEBREW_PREFIX/etc";;
 				*)
 					>&2 echo 'error: unsupported installation path - failed to establish fallback' ;
 					exit 5;;


### PR DESCRIPTION
This PR is my initial attempt at adding macOS support. Before I spend any more time on this, would you be open to merging macOS support?

Ideally, it would also like to contribute a corresponding formula to Homebrew.

GitHub provides some macOS runners, but using the existing setup with docker won't be possible for macOS, will it?

And as a side not, having to download additional sources by having to clone the project, even when it was installed through a package manager doesn't seem ideal. Is there a particular reason for this design choice? Or would you also welcome some work around building it into the app directly?

Let me know what you think, @filiparag!